### PR TITLE
Fix license value in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
   "authors": [
     "Addy Osmani"
   ],
-  "license": "Apache-2",
+  "license": "Apache-2.0",
   "ignore": [
     "/.*",
     "/test/"


### PR DESCRIPTION
According to bower.json spec (https://github.com/bower/spec/blob/master/json.md#license), "license" value must be one of SPDX license identifiers (https://spdx.org/licenses), "Apache-2" is not a valid SPDX identifier.